### PR TITLE
Tub1

### DIFF
--- a/donkeycar/parts/datastore.py
+++ b/donkeycar/parts/datastore.py
@@ -148,9 +148,11 @@ class Tub(object):
 
     """
 
-    def __init__(self, path, inputs=None, types=None):
+    def __init__(self, path, inputs=None, types=None, location=None, task=None):
 
         self.path = os.path.expanduser(path)
+        self.location = location
+        self.task = task
         #print('path_in_tub:', self.path)
         self.meta_path = os.path.join(self.path, 'meta.json')
         self.df = None
@@ -176,6 +178,10 @@ class Tub(object):
             else:
                 self.start_time = time.time()
                 self.meta['start'] = self.start_time
+            if 'location' in self.meta:
+                self.location = self.meta['location']
+            if 'task' in self.meta:
+                self.task = self.meta['task']
 
         elif not exists and inputs:
             print('Tub does NOT exist. Creating new tub...')
@@ -183,6 +189,10 @@ class Tub(object):
             #create log and save meta
             os.makedirs(self.path)
             self.meta = {'inputs': inputs, 'types': types, 'start': self.start_time}
+            if self.location:
+                self.meta['location'] = self.location
+            if self.task:
+                self.meta['task'] = self.task
             with open(self.meta_path, 'w') as f:
                 json.dump(self.meta, f)
             self.current_ix = 0
@@ -554,9 +564,9 @@ class TubHandler():
         tub_path = os.path.join(self.path, name)
         return tub_path
 
-    def new_tub_writer(self, inputs, types):
+    def new_tub_writer(self, inputs, types, location=None, task=None):
         tub_path = self.create_tub_path()
-        tw = TubWriter(path=tub_path, inputs=inputs, types=types)
+        tw = TubWriter(path=tub_path, inputs=inputs, types=types, location=location, task=task)
         return tw
 
 

--- a/donkeycar/parts/datastore.py
+++ b/donkeycar/parts/datastore.py
@@ -148,11 +148,9 @@ class Tub(object):
 
     """
 
-    def __init__(self, path, inputs=None, types=None, location=None, task=None):
+    def __init__(self, path, inputs=None, types=None, user_meta=[]):
 
         self.path = os.path.expanduser(path)
-        self.location = location
-        self.task = task
         #print('path_in_tub:', self.path)
         self.meta_path = os.path.join(self.path, 'meta.json')
         self.df = None
@@ -178,10 +176,6 @@ class Tub(object):
             else:
                 self.start_time = time.time()
                 self.meta['start'] = self.start_time
-            if 'location' in self.meta:
-                self.location = self.meta['location']
-            if 'task' in self.meta:
-                self.task = self.meta['task']
 
         elif not exists and inputs:
             print('Tub does NOT exist. Creating new tub...')
@@ -189,10 +183,11 @@ class Tub(object):
             #create log and save meta
             os.makedirs(self.path)
             self.meta = {'inputs': inputs, 'types': types, 'start': self.start_time}
-            if self.location:
-                self.meta['location'] = self.location
-            if self.task:
-                self.meta['task'] = self.task
+            for kv in user_meta:
+                kvs = kv.split(":")
+                if len(kvs) == 2:
+                    self.meta[kvs[0]] = kvs[1]
+                # else exception? print message?
             with open(self.meta_path, 'w') as f:
                 json.dump(self.meta, f)
             self.current_ix = 0
@@ -564,9 +559,9 @@ class TubHandler():
         tub_path = os.path.join(self.path, name)
         return tub_path
 
-    def new_tub_writer(self, inputs, types, location=None, task=None):
+    def new_tub_writer(self, inputs, types, user_meta=[]):
         tub_path = self.create_tub_path()
-        tw = TubWriter(path=tub_path, inputs=inputs, types=types, location=location, task=task)
+        tw = TubWriter(path=tub_path, inputs=inputs, types=types, user_meta=user_meta)
         return tw
 
 

--- a/donkeycar/parts/datastore.py
+++ b/donkeycar/parts/datastore.py
@@ -171,11 +171,18 @@ class Tub(object):
             except ValueError:
                 self.current_ix = 0
 
+            if 'start' in self.meta:
+                self.start_time = self.meta['start']
+            else:
+                self.start_time = time.time()
+                self.meta['start'] = self.start_time
+
         elif not exists and inputs:
             print('Tub does NOT exist. Creating new tub...')
+            self.start_time = time.time()
             #create log and save meta
             os.makedirs(self.path)
-            self.meta = {'inputs': inputs, 'types': types}
+            self.meta = {'inputs': inputs, 'types': types, 'start': self.start_time}
             with open(self.meta_path, 'w') as f:
                 json.dump(self.meta, f)
             self.current_ix = 0
@@ -185,8 +192,6 @@ class Tub(object):
                   "to create a new tub. Please check your tub path or provide meta info to create a new tub."
 
             raise AttributeError(msg)
-
-        self.start_time = time.time()
 
 
     def get_last_ix(self):
@@ -330,6 +335,8 @@ class Tub(object):
             else:
                 msg = 'Tub does not know what to do with this type {}'.format(typ)
                 raise TypeError(msg)
+
+        json_data['milliseconds'] = int((time.time() - self.start_time) * 1000)
 
         self.write_json_record(json_data)
         return self.current_ix

--- a/donkeycar/templates/config_defaults.py
+++ b/donkeycar/templates/config_defaults.py
@@ -174,3 +174,7 @@ DONKEY_GYM_ENV_NAME = "donkey-generated-track-v0" # "donkey-generated-track-v0" 
 
 #publish camera over network
 PUB_CAMERA_IMAGES = False
+
+#meta data. Strings describing location and/or task
+DRIVE_LOCATION = None
+DRIVE_TASK = None

--- a/donkeycar/templates/donkey2.py
+++ b/donkeycar/templates/donkey2.py
@@ -4,12 +4,13 @@ Scripts to drive a donkey 2 car
 
 Usage:
     manage.py (drive) [--model=<model>] [--js] [--type=(linear|categorical|rnn|imu|behavior|3d|localizer|latent)] [--camera=(single|stereo)]
-    manage.py (train) [--tub=<tub1,tub2,..tubn>] (--model=<model>) [--transfer=<model>] [--type=(linear|categorical|rnn|imu|behavior|3d|localizer)] [--continuous] [--aug]
+    manage.py (train) [--tub=<tub1,tub2,..tubn>] [--file=<file> ...] (--model=<model>) [--transfer=<model>] [--type=(linear|categorical|rnn|imu|behavior|3d|localizer)] [--continuous] [--aug]
 
 
 Options:
-    -h --help     Show this screen.
-    --js          Use physical joystick.
+    -h --help        Show this screen.
+    --js             Use physical joystick.
+    -f --file=<file> A text file containing paths to tub files, one per line. Option may be used more than once.
 """
 import os
 import time
@@ -519,7 +520,7 @@ if __name__ == '__main__':
         drive(cfg, model_path = args['--model'], use_joystick=args['--js'], model_type=model_type, camera_type=camera_type)
     
     if args['train']:
-        from train import multi_train
+        from train import multi_train, preprocessFileList
         
         tub = args['--tub']
         model = args['--model']
@@ -527,7 +528,13 @@ if __name__ == '__main__':
         model_type = args['--type']
         continuous = args['--continuous']
         aug = args['--aug']     
-        multi_train(cfg, tub, model, transfer, model_type, continuous, aug)
+
+        dirs = preprocessFileList( args['--file'] )
+        if tub is not None:
+            tub_paths = [os.path.expanduser(n) for n in tub.split(',')]
+            dirs.extend( tub_paths )
+
+        multi_train(cfg, dirs, model, transfer, model_type, continuous, aug)
 
 
 

--- a/donkeycar/templates/train.py
+++ b/donkeycar/templates/train.py
@@ -11,10 +11,11 @@ You might need to do a: pip install scikit-learn
 
 
 Usage:
-    train.py [--tub=<tub1,tub2,..tubn>] (--model=<model>) [--transfer=<model>] [--type=(linear|latent|categorical|rnn|imu|behavior|3d|look_ahead)] [--continuous] [--aug]
+    train.py [--tub=<tub1,tub2,..tubn>] [--file=<file> ...] (--model=<model>) [--transfer=<model>] [--type=(linear|latent|categorical|rnn|imu|behavior|3d|look_ahead)] [--continuous] [--aug]
 
 Options:
-    -h --help     Show this screen.    
+    -h --help        Show this screen.
+    -f --file=<file> A text file containing paths to tub files, one per line. Option may be used more than once.
 """
 import os
 import glob
@@ -942,6 +943,24 @@ def get_model_apoz(model, generator):
     return apoz_df
 
     
+def removeComments( dir_list ):
+    for i in reversed(range(len(dir_list))):
+        if dir_list[i].startswith("#"):
+            del dir_list[i]
+        elif len(dir_list[i]) == 0:
+            del dir_list[i]
+
+def preprocessFileList( filelist ):
+    dirs = []
+    if filelist is not None:
+        for afile in filelist:
+            with open(afile, "r") as f:
+                tmp_dirs = f.read().split('\n')
+                dirs.extend(tmp_dirs)
+
+    removeComments( dirs )
+    return dirs
+
 if __name__ == "__main__":
     args = docopt(__doc__)
     cfg = dk.load_config()
@@ -951,5 +970,10 @@ if __name__ == "__main__":
     model_type = args['--type']
     continuous = args['--continuous']
     aug = args['--aug']
-    multi_train(cfg, tub, model, transfer, model_type, continuous, aug)
     
+    dirs = preprocessFileList( args['--file'] )
+    if tub is not None:
+        tub_paths = [os.path.expanduser(n) for n in tub.split(',')]
+        dirs.extend( tub_paths )
+
+    multi_train(cfg, dirs, model, transfer, model_type, continuous, aug)

--- a/donkeycar/tests/test_tub.py
+++ b/donkeycar/tests/test_tub.py
@@ -2,6 +2,7 @@
 import tempfile
 import unittest
 from donkeycar.parts.datastore import TubWriter, Tub
+from donkeycar.parts.datastore import TubHandler
 import os
 
 import pytest
@@ -36,13 +37,10 @@ def test_tub_add_record(tub):
         rec_out.pop('milliseconds')
     assert rec_in.keys() == rec_out.keys()
 
-
-
-
 class TestTubWriter(unittest.TestCase):
     def setUp(self):
-        tempfolder = tempfile.TemporaryDirectory()
-        self.path = os.path.join(tempfolder.name, 'new')
+        self.tempfolder = tempfile.TemporaryDirectory().name
+        self.path = os.path.join(self.tempfolder, 'new')
         self.inputs = ['name', 'age', 'pic']
         self.types = ['str', 'float', 'str']
 
@@ -60,4 +58,26 @@ class TestTubWriter(unittest.TestCase):
         abs_record_dict = tub.make_record_paths_absolute(record_dict)
 
         assert abs_record_dict['file_path'] == os.path.join(self.path, rel_file_name)
+
+    def test_tub_meta(self):
+        meta = ["location:Here", "task:sometask"]
+        tub = Tub(self.path, inputs=['file_path'], types=['image'], user_meta=meta)
+        t2 = Tub(self.path)
+        assert "location" in tub.meta
+        assert "location" in t2.meta
+        assert "sometask" == t2.meta["task"]
+
+    def test_tub_like_driver(self):
+        """ The manage.py/donkey2.py drive command creates a tub using TubHandler,
+            so test that way.
+        """
+        os.makedirs(self.tempfolder)
+        meta = ["location:Here2", "task:sometask2"]
+        th = TubHandler(self.tempfolder)
+        tub = th.new_tub_writer(inputs=self.inputs, types=self.types, user_meta=meta)
+        t2 = Tub(tub.path)
+        assert tub.meta == t2.meta
+        assert tub.meta['location'] == "Here2"
+        assert t2.meta['inputs'] == self.inputs
+        assert t2.meta['location'] == "Here2"
 

--- a/donkeycar/tests/test_tub.py
+++ b/donkeycar/tests/test_tub.py
@@ -31,6 +31,9 @@ def test_tub_add_record(tub):
     rec_in  = {'cam/image_array': img_arr, 'user/angle': x, 'user/throttle':y}
     rec_index = tub.put_record(rec_in)
     rec_out = tub.get_record(rec_index)
+    # Ignore the milliseconds key, which is added when the record is written
+    if 'milliseconds' in rec_out:
+        rec_out.pop('milliseconds')
     assert rec_in.keys() == rec_out.keys()
 
 

--- a/donkeycar/utils.py
+++ b/donkeycar/utils.py
@@ -351,7 +351,10 @@ def gather_tub_paths(cfg, tub_names=None):
     returns a list of Tub paths
     '''
     if tub_names:
-        tub_paths = [os.path.expanduser(n) for n in tub_names.split(',')]
+        if type(tub_names) == list:
+            tub_paths = [os.path.expanduser(n) for n in tub_names]
+        else:
+            tub_paths = [os.path.expanduser(n) for n in tub_names.split(',')]
         return expand_path_masks(tub_paths)
     else:
         paths = [os.path.join(cfg.DATA_PATH, n) for n in os.listdir(cfg.DATA_PATH)]


### PR DESCRIPTION
Added three items to meta.json: start time (float, unix timestamp), location (string) and task (string).
Location and task can be passed on the command line, or via config. Start time doesn't have an option, although it probably should.
Time offset from start time is also added to each record.json file.

I also added a -f/--file option to the train.py script, which reads a text file with one tub path per line and adds them to any tubs passed directly on the command line.