### PR TITLE
Added support for an exclude.json file to the Tub class.

### DIFF
--- a/donkeycar/parts/datastore.py
+++ b/donkeycar/parts/datastore.py
@@ -153,6 +153,7 @@ class Tub(object):
         self.path = os.path.expanduser(path)
         #print('path_in_tub:', self.path)
         self.meta_path = os.path.join(self.path, 'meta.json')
+        self.exclude_path = os.path.join(self.path, "exclude.json")
         self.df = None
 
         exists = os.path.exists(self.path)
@@ -165,6 +166,13 @@ class Tub(object):
                     self.meta = json.load(f)
             except FileNotFoundError:
                 self.meta = {'inputs': [], 'types': []}
+
+            try:
+                with open(self.exclude_path,'r') as f:
+                    excl = json.load(f) # stored as a list
+                    self.exclude = set(excl)
+            except FileNotFoundError:
+                self.exclude = set()
 
             try:
                 self.current_ix = self.get_last_ix() + 1
@@ -191,6 +199,7 @@ class Tub(object):
             with open(self.meta_path, 'w') as f:
                 json.dump(self.meta, f)
             self.current_ix = 0
+            self.exclude = set()
             print('New tub created at: {}'.format(self.path))
         else:
             msg = "The tub path you provided doesn't exist and you didnt pass any meta info (inputs & types)" + \
@@ -418,6 +427,15 @@ class Tub(object):
         return data
 
 
+    def gather_records(self):
+        ri = lambda fnm : int( os.path.basename(fnm).split('_')[1].split('.')[0] )
+
+        record_paths = glob.glob(os.path.join(self.path, 'record_*.json'))
+        if len(self.exclude) > 0:
+            record_paths = [f for f in record_paths if ri(f) not in self.exclude]
+        record_paths.sort(key=ri)
+        return record_paths
+
     def make_file_name(self, key, ext='.png'):
         name = '_'.join([str(self.current_ix), key, ext])
         name = name = name.replace('/', '-')
@@ -431,6 +449,27 @@ class Tub(object):
     def shutdown(self):
         pass
 
+
+    def excluded(self, index):
+        return index in self.exclude
+
+    def exclude_index(self, index):
+        self.exclude.add(index)
+
+    def include_index(self, index):
+        try:
+            self.exclude.remove(index)
+        except:
+            pass
+
+    def write_exclude(self):
+        if 0 == len(self.exclude):
+            # If the exclude set is empty don't leave an empty file around.
+            if os.path.exists(self.exclude_path):
+                os.unlink(self.exclude_path)
+        else:
+            with open(self.exclude_path,'w') as f:
+                json.dump( list(self.exclude), f )
 
     def get_record_gen(self, record_transform=None, shuffle=True, df=None):
 

--- a/donkeycar/tests/test_tub.py
+++ b/donkeycar/tests/test_tub.py
@@ -18,7 +18,7 @@ def test_tub_load(tub, tub_path):
 
 
 def test_tub_update_df(tub):
-    """ Tub updats its dataframe """
+    """ Tub updates its dataframe """
     tub.update_df()
     assert len(tub.df) == 128
 
@@ -48,6 +48,21 @@ def test_tub_write_numpy(tub):
     rec_out = tub.get_record(rec_index)
     assert type(rec_out['user/throttle']) == float
 
+
+def test_tub_exclude(tub):
+    """ Make sure the Tub will exclude records in the exclude set """
+    ri = lambda fnm : int( os.path.basename(fnm).split('_')[1].split('.')[0] )
+
+    before = tub.gather_records()
+    assert len(before) == tub.get_num_records() # Make sure we gathered records correctly
+    tub.exclude.add(1)
+    after = tub.gather_records()
+    assert len(after) == (tub.get_num_records() - 1) # Make sure we excluded the correct number of records
+    before = set([ri(f) for f in before])
+    after = set([ri(f) for f in after])
+    diff = before - after
+    assert len(diff) == 1
+    assert 1 in diff # Make sure we exclude the correct index
 
 class TestTubWriter(unittest.TestCase):
     def setUp(self):

--- a/donkeycar/utils.py
+++ b/donkeycar/utils.py
@@ -395,8 +395,7 @@ def gather_records(cfg, tub_names, opts=None, verbose=False):
     for tub in tubs:
         if verbose:
             print(tub.path)
-        record_paths = glob.glob(os.path.join(tub.path, 'record_*.json'))
-        record_paths.sort(key=get_record_index)
+        record_paths = tub.gather_records()
         records += record_paths
 
     return records


### PR DESCRIPTION
 Training code will skip any records in the exclude list.

Should have no effect unless you create an exclude.json file in a Tub directory, with a list of indexes to exclude from training.

e.g.
`tub.include_index(1)
tub.include_index(99)
tub.write_exclude()`